### PR TITLE
Add option to use WebGPU as the execution provider

### DIFF
--- a/inference.js
+++ b/inference.js
@@ -70,9 +70,9 @@ function usage()
 {
   console.log(`inference.js: Perform inferencing on upload a machine learning model via DCP.
 Usage:
-    node inference.js [--batch=<size>] [--output=<outputFile>]
+    node inference.js </path/to/model.json> </path/to/input/dir>
+                      [--batch=<size>] [--output=<outputFile>]
                       [--computeGroup=<joinKey,joinSecret>] [--webgpu] [--help]
-                      </path/to/model.json> </path/to/input/dir>
 
 Where:
     --batch         is the batch size for each slice

--- a/inference.js
+++ b/inference.js
@@ -47,7 +47,11 @@ async function deploy(inputSet, modelName, computeGroup, output, webgpu)
 	job.on('error', async function errorHandler(err) {
 		console.error(err);
 	});
-  // job.on('console', console.log)
+  job.on('console', (event) => {
+    if (event.message[0].common) {
+      console.log('ONNX Runtime Version:', event.message[0].common);
+    }
+  });
 
   let resultSet = [];
   try {

--- a/inference.js
+++ b/inference.js
@@ -21,8 +21,8 @@ async function deploy(inputSet, modelName, computeGroup, output, webgpu)
 	let job = compute.for(inputSet, workFunction, [labels]);
 
   job.public.name = `DCP Inferencing: ${modelName}`;
-  job.requires('dcp-ort-test/dcp-wasm.js');
-  job.requires('dcp-ort-test/dcp-ort.js');
+  job.requires('onnxruntime-dcp/dcp-wasm.js');
+  job.requires('onnxruntime-dcp/dcp-ort.js');
   job.requires('pyodide-core/pyodide-core.js');
   job.requires(`${modelName}/module.js`);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,6 @@
   "packages": {
     "": {
       "name": "simple-inference",
-      "version": "1.0.0",
-      "license": "ISC",
       "dependencies": {
         "dcp-client": "^4.4.23",
         "dcp-util": "^2.3.13"

--- a/package.json
+++ b/package.json
@@ -1,15 +1,13 @@
 {
   "name": "simple-inference",
-  "version": "1.0.0",
-  "main": "dcpJob.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "author": "",
-  "license": "MIT",
-  "description": "",
+  "private": true,
+  "description": "Simple machine learning inferencing through DCP",
+  "author": "Ryan Saweczko <ryansaweczko@distributive.network>",
+  "main": "inference.js",
+  "scripts": {},
   "dependencies": {
     "dcp-client": "^4.4.23",
     "dcp-util": "^2.3.13"
-  }
+  },
+  "packageManager": "npm@11.2.0"
 }

--- a/workFunction.js
+++ b/workFunction.js
@@ -42,6 +42,7 @@ async function workFunction(sliceData, labels) {
 	};
 
 	ort.env.wasm.simd = true;
+  console.log(ort.env.versions);
 
 	// add else -> comments get run
 	if (!globalThis.session) {

--- a/workFunction.js
+++ b/workFunction.js
@@ -46,7 +46,7 @@ async function workFunction(sliceData, labels) {
 	// add else -> comments get run
 	if (!globalThis.session) {
     globalThis.session = await ort.InferenceSession.create(model, {
-      executionProviders    : [ 'wasm' ],
+      executionProviders    : [labels['webgpu'] ? 'webgpu' : 'wasm'],
       graphOptimizationLevel: 'all'
     });
 	}


### PR DESCRIPTION
With an update "`dcp-ort`" package, this PR adds a new `--webgpu` option to `inference.js`, which enables folks to using WebGPU as the backend for their inferencing jobs.